### PR TITLE
Work on #1 - update help text in admin form and fix default value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 Configuration path is admin/islandora/tools/badges/creativecommons (Administration > Islandora > Islandora Utility Modules > Islandora Badges Configuration > CC Badge).
 
-Solr field for Creative Commons license URI: Defaults to mods_accessCondition_ms. Multivalued field recommended if working with other accessCondition fields.
+Solr field for Creative Commons license URI: Defaults to `dc.rights`. Multivalued field recommended if working with other accessCondition fields.
 
 ## Troubleshooting/Issues
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -10,8 +10,8 @@ function islandora_cc_badge_admin_form($form, $form_settings) {
   $form['islandora_cc_badge_license_field'] = array(
     '#type' => 'textfield',
     '#title' => t('Solr field for Creative Commons license URI'),
-    '#description' => t('Solr field for Creative Commons license URI. Must be multivalued (e.g., has a _m at the end of the field name).'),
-    '#default_value' => variable_get('islandora_cc_badge_license_field', 'mods_accessCondition_ms'),
+    '#description' => t('Solr field for Creative Commons license URI. If a field from MODS, must be multivalued (e.g., has a _m at the end of the field name).'),
+    '#default_value' => variable_get('islandora_cc_badge_license_field', 'dc.rights'),
   );
 
   return system_settings_form($form);

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -10,8 +10,8 @@ function islandora_cc_badge_admin_form($form, $form_settings) {
   $form['islandora_cc_badge_license_field'] = array(
     '#type' => 'textfield',
     '#title' => t('Solr field for Creative Commons license URI'),
-    '#description' => t('Solr field that contains the CC license URI.'),
-    '#default_value' => variable_get('islandora_cc_badge_license_field', 'dc.rights'),
+    '#description' => t('Solr field for Creative Commons license URI. Must be multivalued (e.g., has a _m at the end of the field name).'),
+    '#default_value' => variable_get('islandora_cc_badge_license_field', 'mods_accessCondition_ms'),
   );
 
   return system_settings_form($form);

--- a/islandora_cc_badge.module
+++ b/islandora_cc_badge.module
@@ -42,7 +42,7 @@ function islandora_cc_badge_get_license(AbstractObject $object) {
     '@field' => 'PID',
     '@pid' =>"{$object->id}")
   ));
-  $uri_field = variable_get('islandora_cc_badge_license_field', 'dc.rights');
+  $uri_field = variable_get('islandora_cc_badge_license_field', 'mods_accessCondition_ms');
   $qp->solrParams['fl'] = implode(', ', array(
     'PID',
     $uri_field,

--- a/islandora_cc_badge.module
+++ b/islandora_cc_badge.module
@@ -42,7 +42,7 @@ function islandora_cc_badge_get_license(AbstractObject $object) {
     '@field' => 'PID',
     '@pid' =>"{$object->id}")
   ));
-  $uri_field = variable_get('islandora_cc_badge_license_field', 'mods_accessCondition_ms');
+  $uri_field = variable_get('islandora_cc_badge_license_field', 'dc.rights');
   $qp->solrParams['fl'] = implode(', ', array(
     'PID',
     $uri_field,


### PR DESCRIPTION
Test this by:

1. Checking out the `issue-1` branch from https://github.com/mjordan/islandora_creative_commons.git.
1. Go to `admin/islandora/tools/badges/creativecommons`. The help text should say "Solr field for Creative Commons license URI. Must be multivalued (e.g., has a _m at the end of the field name)."
1. I don't know how to test a change in the default value other than to look at line 45 of islandora_cc_badge.module and line 14 of admin.form.inc.