### PR TITLE
Strip https from Creative Commons API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This module requires the following modules/libraries:
 
 * [Islandora](https://github.com/islandora/islandora)
 * [Islandora Solr](https://github.com/islandora/islandora_solr)
-* [Islandora Badges](../../)
+* [Islandora Badges](https://github.com/Islandora/islandora_badges)
 
 ## Installation
 

--- a/islandora_cc_badge.module
+++ b/islandora_cc_badge.module
@@ -87,8 +87,8 @@ function islandora_cc_badge_block_view($delta = '') {
         }
         else {
           // Set API endpoint URL
-          $url = "http://api.creativecommons.org/rest/1.5";
-          $request_url = $url . '/details?license-uri=' . $license_uri;
+          $url = "https://api.creativecommons.org/rest/1.5";
+          $request_url = $url . '/details?license-uri=' . preg_replace('/https:\/\//','http://',$license_uri);
           // Make the request and get results!
           $result_xml = drupal_http_request($request_url);
           if (!isset($result_xml->error)) {


### PR DESCRIPTION
The (aging) Creative Commons API doesn't seem to like https URIs and treat them as invalid. This fix replaces https URIs with http ones for the purpose of the API call.

Compare https://api.creativecommons.org/rest/dev/details?license-uri=https://creativecommons.org/licenses/by-nc-sa/4.0/
with https://api.creativecommons.org/rest/dev/details?license-uri=http://creativecommons.org/licenses/by-nc-sa/4.0/

Also fixes broken reference to Islandora Badges in the README.